### PR TITLE
Stop rewards from getting higher than the collateral

### DIFF
--- a/igb.html
+++ b/igb.html
@@ -103,20 +103,21 @@
         if (collateral*0.001*jumps > reward) {
             reward = collateral*0.001*jumps;
         }
-
+               
+        if (reward >= (collateral*0.5) ) {
+          reward = collateral*0.3;
+        }
+        
         // Let's round up to make it look purdy
         reward = Math.round(reward/1000)*1000;
-
+        
         // Extra Fees
         if ($('#rush').prop('checked')) {
           reward = reward * 2;
         }
-
+        
         if ($('#lowsec').prop('checked')) {
           reward = reward * 2;
-        }
-        if (reward >= (collateral*0.5) ) {
-          reward = collateral*0.3;
         }
         // updates prices displayed in text
         if (reward > 0) {

--- a/igb.html
+++ b/igb.html
@@ -115,7 +115,7 @@
         if ($('#lowsec').prop('checked')) {
           reward = reward * 2;
         }
-        if (collateral <= 1000000) {
+        if (reward >= (collateral*0.5) ) {
           reward = collateral*0.3;
         }
         // updates prices displayed in text

--- a/igb.html
+++ b/igb.html
@@ -8,7 +8,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="style-igb.css">
   <script src="utils.js"></script>
-  <script>
+ <script>
     $(document).ready(function(){
 
       // Used by the auto copy to clipboard
@@ -115,7 +115,9 @@
         if ($('#lowsec').prop('checked')) {
           reward = reward * 2;
         }
-        
+        if (collateral <= 1000000) {
+          reward = collateral*0.3;
+        }
         // updates prices displayed in text
         if (reward > 0) {
           $('#reward_label').addClass('active');

--- a/ogb.html
+++ b/ogb.html
@@ -103,20 +103,21 @@
         if (collateral*0.001*jumps > reward) {
             reward = collateral*0.001*jumps;
         }
-
+               
+        if (reward >= (collateral*0.5) ) {
+          reward = collateral*0.3;
+        }
+        
         // Let's round up to make it look purdy
         reward = Math.round(reward/1000)*1000;
-
+        
         // Extra Fees
         if ($('#rush').prop('checked')) {
           reward = reward * 2;
         }
-
+        
         if ($('#lowsec').prop('checked')) {
           reward = reward * 2;
-        }
-        if (collateral <= 1000000) {
-          reward = collateral*0.3;
         }
         // updates prices displayed in text
         if (reward > 0) {

--- a/ogb.html
+++ b/ogb.html
@@ -115,7 +115,7 @@
         if ($('#lowsec').prop('checked')) {
           reward = reward * 2;
         }
-        if (collateral < 1000000) {
+        if (collateral <= 1000000) {
           reward = collateral*0.1;
         }
         // updates prices displayed in text

--- a/ogb.html
+++ b/ogb.html
@@ -115,7 +115,9 @@
         if ($('#lowsec').prop('checked')) {
           reward = reward * 2;
         }
-        
+        if (collateral < 1000000) {
+          reward = collateral*0.1;
+        }
         // updates prices displayed in text
         if (reward > 0) {
           $('#reward_label').addClass('active');

--- a/ogb.html
+++ b/ogb.html
@@ -116,7 +116,7 @@
           reward = reward * 2;
         }
         if (collateral <= 1000000) {
-          reward = collateral*0.1;
+          reward = collateral*0.3;
         }
         // updates prices displayed in text
         if (reward > 0) {


### PR DESCRIPTION
Fixed issue where very low collaterals would result in rewards higher than the collat. Should default to 30% of the collateral if this happens now.